### PR TITLE
fix(eol-shared): preserve only EOL-relevant SBOM properties

### DIFF
--- a/src/trim-cdx-bom.test.ts
+++ b/src/trim-cdx-bom.test.ts
@@ -5,7 +5,7 @@ import type { CdxBom } from './types/index.ts';
 import { Enums } from '@cyclonedx/cyclonedx-library';
 
 describe('trimCdxBom', () => {
-  test('should remove external references, evidence, hashes, and properties from components', () => {
+  test('should remove external references, evidence, hashes, and non-EOL properties from components', () => {
     const mockBom: CdxBom = {
       bomFormat: 'CycloneDX',
       specVersion: '1.4',
@@ -24,7 +24,10 @@ describe('trimCdxBom', () => {
           hashes: [
             { alg: Enums.HashAlgorithm['SHA-1'], content: 'hash-content' },
           ],
-          properties: [{ name: 'prop1', value: 'value1' }],
+          properties: [
+            { name: 'prop1', value: 'value1' },
+            { name: 'gradleProfileName', value: 'runtimeClasspath' },
+          ],
         },
         {
           type: Enums.ComponentType.Library,
@@ -37,7 +40,10 @@ describe('trimCdxBom', () => {
           ],
           evidence: { copyright: [] },
           hashes: [{ alg: Enums.HashAlgorithm['MD5'], content: 'md5-hash' }],
-          properties: [{ name: 'prop2', value: 'value2' }],
+          properties: [
+            { name: 'prop2', value: 'value2' },
+            { name: 'GradleProfileName', value: 'testRuntimeClasspath' },
+          ],
         },
       ],
     };
@@ -49,13 +55,15 @@ describe('trimCdxBom', () => {
       externalReferences: [],
       evidence: {},
       hashes: [],
-      properties: [],
+      properties: [{ name: 'gradleProfileName', value: 'runtimeClasspath' }],
     });
     assert.partialDeepStrictEqual(result.components![1], {
       externalReferences: [],
       evidence: {},
       hashes: [],
-      properties: [],
+      properties: [
+        { name: 'GradleProfileName', value: 'testRuntimeClasspath' },
+      ],
     });
   });
 

--- a/src/trim-cdx-bom.ts
+++ b/src/trim-cdx-bom.ts
@@ -1,8 +1,10 @@
 import type { CdxBom } from './types/index.ts';
 
+const EOL_SCAN_PROPERTY_ALLOWLIST = new Set(['gradleprofilename']);
+
 /**
  * Creates a trimmed copy of a CycloneDX BOM by removing SBOM data not necessary for EOL scanning.
- * Removes externalReferences, evidence, hashes, and properties from components.
+ * Removes externalReferences, evidence, hashes, and non-EOL properties from components.
  * @param cdxBom - The CycloneDX BOM to trim
  * @returns A new trimmed CycloneDX BOM object
  */
@@ -13,6 +15,10 @@ export function trimCdxBom(cdxBom: CdxBom): CdxBom {
     component.externalReferences = [];
     component.evidence = {};
     component.hashes = [];
+    component.properties =
+      component.properties?.filter((property) =>
+        EOL_SCAN_PROPERTY_ALLOWLIST.has(property.name?.toLowerCase() ?? ''),
+      ) ?? [];
   }
 
   return newBom;


### PR DESCRIPTION
## What This Branch Does

This branch tightens SBOM trimming for EOL scans by making [`trimCdxBom`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941R11) remove non-EOL component properties before upload. It keeps the existing trimming behavior for external references, evidence, and hashes, while preserving the Maven/Gradle property currently used by EOL report analysis.

## SBOM Trimming

- Adds [`EOL_SCAN_PROPERTY_ALLOWLIST`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941R3) in [`src/trim-cdx-bom.ts`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941) to keep only EOL-relevant CycloneDX component properties.
- Updates [`trimCdxBom`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941R11) to filter component properties case-insensitively and preserve `gradleProfileName` while dropping unrelated property payloads.
- Keeps empty property arrays for components without allowlisted properties in [`src/trim-cdx-bom.ts`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941R18-R21), matching the existing trimmed-output style for hashes, evidence, and external references.

## Test Coverage

- Updates the [`trimCdxBom`](https://github.com/herodevs/eol-shared/pull/26/files#diff-d53912917531ebd1e4dad15dcadcef4de06053083821b405476f9425ef7f3941R11) unit test in [`src/trim-cdx-bom.test.ts`](https://github.com/herodevs/eol-shared/pull/26/files#diff-c3d029e75c1a60de2243dd0c586eb17127ded9ca977e1005c33852a640f41d8f) to cover non-EOL property removal.
- Adds test fixtures for both lowercase and mixed-case `gradleProfileName` properties in [`src/trim-cdx-bom.test.ts`](https://github.com/herodevs/eol-shared/pull/26/files#diff-c3d029e75c1a60de2243dd0c586eb17127ded9ca977e1005c33852a640f41d8fR27-R45).
- Verifies that allowlisted properties are retained after trimming in [`src/trim-cdx-bom.test.ts`](https://github.com/herodevs/eol-shared/pull/26/files#diff-c3d029e75c1a60de2243dd0c586eb17127ded9ca977e1005c33852a640f41d8fR55-R64).