### PR TITLE
feat: add per-component remediations type to EolScanComponent

### DIFF
--- a/src/types/eol-scan.ts
+++ b/src/types/eol-scan.ts
@@ -32,10 +32,45 @@ export interface NesRemediation {
   }[];
 }
 
+export type RemediationType =
+  | 'nes_available'
+  | 'nes_ready'
+  | 'version_update'
+  | 'package_replacement';
+
+export type RemediationActionType =
+  | 'direct'
+  | 'contact'
+  | 'enterprise_portal'
+  | 'automated'
+  | 'reference';
+
+export interface RemediationAction {
+  type: RemediationActionType;
+  url?: string;
+}
+
+export interface RemediationTarget {
+  purl: string;
+  version?: string | null;
+  releasedAt?: string | null;
+  publishPurl?: string | null;
+  nesPurl?: string | null;
+  ossPurl?: string | null;
+}
+
+export interface Remediation {
+  type: RemediationType;
+  description: string;
+  action: RemediationAction;
+  target?: RemediationTarget;
+}
+
 export interface EolScanComponent {
   metadata: EolScanComponentMetadata | null;
   purl: string;
   nesRemediation?: NesRemediation | null;
+  remediations?: Remediation[] | null;
 }
 
 export interface EolReportMetadata {


### PR DESCRIPTION
## What This Branch Does

Adds a typed, per-component `remediations` field to the shared EOL scan model. A new
[`Remediation`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR62)
type (plus its supporting union and target/action types) is introduced and exposed on
[`EolScanComponent`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR69)
as an optional field. Types-only change with no runtime behavior.

## Remediations Type

Mirrors the `EnrichedRemediationFact` shape served by eol-api so consumers get a precise type instead of untyped passthrough.

- [`RemediationType`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR35) — union: `nes_available | nes_ready | version_update | package_replacement`.
- [`RemediationActionType`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR41) — union: `direct | contact | enterprise_portal | automated | reference`.
- [`RemediationAction`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR48) — `{ type, url? }`.
- [`RemediationTarget`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR53) — `{ purl, version?, releasedAt?, publishPurl?, nesPurl?, ossPurl? }`.
- [`Remediation`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR62) — `{ type, description, action, target? }`.
- [`EolScanComponent.remediations`](https://github.com/herodevs/eol-shared/pull/27/files#diff-8b290cf483a1b9626fff470af86dc7c111143a71d0ed86164e5928b3b96c367aR73) — new optional `Remediation[] | null` field, sibling of `nesRemediation`.

All types are re-exported from the package root via `export type * from './types/eol-scan.js'`.

## Compatibility

Additive and backward-compatible: the new field is optional, so existing consumers and fixtures compile unchanged. No runtime logic changes.

## Known Gaps / Downstream

- Consumed by the HeroDevs CLI to include `remediations` per component in its saved JSON report; the CLI bumps its dependency to the tag cut from this PR (`v0.1.20`).
- **Release coordination:** the CLI must not ship until the eol-api **prod** schema exposes `EolComponentScanResult.remediations`, or the CLI's GraphQL query selecting `remediations` fails validation. Depends on the eol-engine prod cutover + API deploy.
