### PR TITLE
fix(eol): classify unknown-metadata components as UNKNOWN

### DIFF
--- a/src/eol/utils.test.ts
+++ b/src/eol/utils.test.ts
@@ -6,6 +6,7 @@ import {
   createPurlIdentity,
   canonicalizeVersionFilter,
 } from './utils.ts';
+import { isUnknownReason, UNKNOWN_REASONS } from '../types/eol-scan.ts';
 import type { EolScanComponentMetadata } from '../types/eol-scan.ts';
 
 // These are required for the object but not used to derive the status
@@ -83,6 +84,42 @@ describe('deriveComponentStatus', () => {
 
     const result = deriveComponentStatus(metadata);
     assert.equal(result, 'OK');
+  });
+
+  for (const unknownReason of UNKNOWN_REASONS) {
+    test(`should return UNKNOWN for unknownReason "${unknownReason}"`, () => {
+      const result = deriveComponentStatus({ unknownReason });
+      assert.equal(result, 'UNKNOWN');
+    });
+  }
+
+  test('should return UNKNOWN for an unrecognized unknownReason value', () => {
+    const result = deriveComponentStatus({
+      unknownReason: 'something_else',
+    } as never);
+    assert.equal(result, 'UNKNOWN');
+  });
+});
+
+describe('isUnknownReason', () => {
+  for (const unknownReason of UNKNOWN_REASONS) {
+    test(`returns true for "${unknownReason}"`, () => {
+      assert.equal(isUnknownReason(unknownReason), true);
+    });
+  }
+
+  test('returns false for null', () => {
+    assert.equal(isUnknownReason(null), false);
+  });
+
+  test('returns false for an unrecognized string', () => {
+    assert.equal(isUnknownReason('something_else'), false);
+  });
+
+  test('returns false for non-string garbage', () => {
+    assert.equal(isUnknownReason(42), false);
+    assert.equal(isUnknownReason(undefined), false);
+    assert.equal(isUnknownReason({}), false);
   });
 });
 

--- a/src/eol/utils.ts
+++ b/src/eol/utils.ts
@@ -1,8 +1,9 @@
 import { PackageURL } from 'packageurl-js';
 import type { CdxBom } from '../types/index.js';
 import type {
+  ComponentMetadata,
   ComponentStatus,
-  EolScanComponentMetadata,
+  UnknownComponentMetadata,
 } from '../types/eol-scan.js';
 
 // Maps non-canonical PURL type tokens to their canonical equivalents.
@@ -243,10 +244,16 @@ export function canonicalizeVersionFilter<
   } as TFilter;
 }
 
+function isUnknownComponentMetadata(
+  metadata: ComponentMetadata,
+): metadata is UnknownComponentMetadata {
+  return 'unknownReason' in metadata && metadata.unknownReason != null;
+}
+
 export function deriveComponentStatus(
-  metadata: EolScanComponentMetadata | null,
+  metadata: ComponentMetadata | null,
 ): ComponentStatus {
-  if (!metadata) {
+  if (!metadata || isUnknownComponentMetadata(metadata)) {
     return 'UNKNOWN';
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export type {
 } from './eol/utils.js';
 
 export type * from './types/eol-scan.js';
+export { UNKNOWN_REASONS, isUnknownReason } from './types/eol-scan.js';
 export type * from './types/index.js';
 
 export { ComponentScope } from './types/index.js';

--- a/src/types/eol-scan.ts
+++ b/src/types/eol-scan.ts
@@ -25,6 +25,28 @@ export interface EolScanNextSupportedVersion {
   releasedAt: Date;
 }
 
+export const UNKNOWN_REASONS = [
+  'not_identifiable',
+  'no_listed_versions',
+  'unsupported_ecosystem',
+  'queued',
+] as const;
+export type UnknownReason = (typeof UNKNOWN_REASONS)[number];
+
+export interface UnknownComponentMetadata {
+  unknownReason: UnknownReason;
+}
+
+export type ComponentMetadata =
+  | EolScanComponentMetadata
+  | UnknownComponentMetadata;
+
+export function isUnknownReason(v: unknown): v is UnknownReason {
+  return (
+    typeof v === 'string' && (UNKNOWN_REASONS as readonly string[]).includes(v)
+  );
+}
+
 export interface NesRemediation {
   remediations: {
     purls: { nes: string; oss: string };
@@ -67,7 +89,7 @@ export interface Remediation {
 }
 
 export interface EolScanComponent {
-  metadata: EolScanComponentMetadata | null;
+  metadata: ComponentMetadata | null;
   purl: string;
   nesRemediation?: NesRemediation | null;
   remediations?: Remediation[] | null;


### PR DESCRIPTION
## Summary

- Fix `deriveComponentStatus` silently classifying unknown/unresolvable packages as `OK` ("Not EOL") after eol-api changed the component `metadata` shape.
- Model the new "unknown" metadata shape in the type system so consumers can detect and narrow it.

## Changes

- **`src/types/eol-scan.ts`** — add `UNKNOWN_REASONS`, `UnknownReason`, `UnknownComponentMetadata`, the `ComponentMetadata` union, and an `isUnknownReason` guard. Widen `EolScanComponent.metadata` to `ComponentMetadata | null` (keep `| null` so legacy null records still resolve to `UNKNOWN`).
- **`src/eol/utils.ts`** — widen `deriveComponentStatus` to `ComponentMetadata | null`; detect a present `unknownReason` before the `isEol`/`eolAt` logic and return `UNKNOWN`. Add a private type guard that narrows the known branch back to `EolScanComponentMetadata` so the existing EOL/EOL_UPCOMING/OK logic typechecks unchanged.
- **`src/index.ts`** — export the runtime values `UNKNOWN_REASONS` and `isUnknownReason`.
- **`src/eol/utils.test.ts`** — add tests for each of the four reasons → `UNKNOWN`, an unrecognized-but-present reason → `UNKNOWN`, `null` → `UNKNOWN`, the existing EOL/EOL_UPCOMING/OK cases, and a full `isUnknownReason` suite.

## Testing

- `npm run build` — pass
- `npm run type-check` (`tsc --noEmit`) — pass
- `npm test` — 200/200 pass (`eol-scan.ts` at 100% coverage)
- `npm run format:check` — clean; `npm run lint` (oxlint) — only pre-existing warnings in `spdx-to-cdx.ts`, none from this change

## Screenshots

n/a

## Risks & Rollback

- **Behavior change (intended):** unknown packages now derive `UNKNOWN` instead of `OK` — this is the fix.
- **Type-level break:** `EolScanComponent.metadata` is now a union. TS consumers that dereference known fields directly off `metadata` (e.g. `metadata.isEol` after only a null check) must narrow first — via `deriveComponentStatus`, `isUnknownReason`, or an `'unknownReason' in metadata` check. Consumers routing UNKNOWN detection through `deriveComponentStatus` are unaffected. Warrants a minor/major version bump.
- Runtime surface is otherwise backward-compatible (no removed/renamed exports, no changed signatures). Rollback is a straight revert of the commit.

## Checklist

- [x] Tests added or updated
- [x] Linting passes
- [x] Typecheck passes (if applicable)
- [ ] No breaking changes without clear migration notes — **type-level break documented above; needs version bump**
- [ ] Environment variables documented (if added/changed) — n/a
